### PR TITLE
ci: trigger build when something is pushed onto the published branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish to GitHub Pages
 on:
   workflow_dispatch:
   push:
-    tags:
-      - 'modelix-2[0-9]+.[0-9]+'
+    branches:
+      - 'docs/release/2[0-9]+.[0-9]+'
   pull_request:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC


### PR DESCRIPTION
We switched from tags to branches and forgot to update the publish.yml